### PR TITLE
SFT-161 update configure script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ tags
 BackupCamera
 
 Installer/SDL*
+build*/
+*.o

--- a/Installer/MainInstaller.sh
+++ b/Installer/MainInstaller.sh
@@ -26,29 +26,19 @@ fi
 apt-get update
 apt-get install -y \
 	build-essential \
-	libcv-dev\
-	libopencv-dev\
-	libao-dev\
-	libasound2-dev\
-	libpulse-dev\
-	libdbus-1-dev\
-	libudev-dev
+	libopencv-dev \
+	libao-dev \
+	libasound2-dev \
+	libpulse-dev \
+	libdbus-1-dev \
+	libudev-dev 
 
 #SDL2.0
 wget https://www.libsdl.org/release/SDL2-2.0.3.tar.gz
 tar -xzvf SDL2-2.0.3.tar.gz
 (	
 	cd SDL2-2.0.3
-	ARCHITECTURE=`uname -m`
-	if [ ${ARCHITECTURE} = "armv7l" ]
-	then
-		echo "Downloading and installing all dependencies for the Raspberry Pi running Raspbian (Debian)"
-	    ./configure --host=armv71-raspberry-linux-gnueabihf --target=arm-raspberry-linux-gnueabihf --disable-video-opengl --disable-video-x11
-	else
-		echo "Downloading and installing all dependencies for general Linux"
-	    ./configure 
-	fi
-
+	./configure
 	make -j4
 	make install -j4
 )

--- a/Installer/MainInstaller.sh
+++ b/Installer/MainInstaller.sh
@@ -10,17 +10,15 @@ finish() {
 	rm -rf $DIR/SDL2_ttf-2.0.12  || true
 	rm -rf $DIR/SDL2-2.0.3 || true
 	rm -rf $DIR/SDL2_mixer-2.0.0 || true
+	rm -rf $DIR/download || true
 }
 
 trap finish EXIT
 
-USER=`whoami`
-if [ $USER = "root" ]
-    then
-    echo "Running as ROOT"
-else
-    echo "***********YOU ARE NOT ROOT************"
-    exit 0
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
 fi
 
 apt-get update
@@ -39,6 +37,16 @@ tar -xzvf SDL2-2.0.3.tar.gz
 (	
 	cd SDL2-2.0.3
 	./configure
+	make -j4
+	make install -j4
+)
+
+#Freetype2 (For SDL2_ttf)
+wget https://sourceforge.net/projects/freetype/files/freetype2/2.10.2/freetype-2.10.2.tar.gz/download
+tar -xzvf download
+(
+	cd freetype-2.10.2
+	./configure --enable-freetype-config
 	make -j4
 	make install -j4
 )


### PR DESCRIPTION
### Changes

#### Update configure script to rely on detected settings
- The flags provided by in the rpi check cause the camera to always open in full screen on newer versions of raspbian. Now we just configure with default settings.
#### Download and Install freetype2
- SDL_TTF needs freetype2 to as a dependency